### PR TITLE
Fix/deps no found

### DIFF
--- a/src/common/index.jsx
+++ b/src/common/index.jsx
@@ -2,10 +2,7 @@ import React from 'react'
 
 const Root = () => {
 	return (
-		<div>
-			<h1>Hello world!</h1>
-			{/* <h2>Hi!</h2> */}
-		</div>
+		<h1>Hello world!</h1>
 	)
 }
 

--- a/src/server/ssr/index.js
+++ b/src/server/ssr/index.js
@@ -3,12 +3,10 @@ import {renderToString} from 'react-dom/server'
 import Html from './Html'
 import Root from 'common'
 import fs from 'fs'
-// const assets = require(`${process.env.CLIENT_DIST_PATH}/webpack-assets.json`)
-// const assets = fs.readFileSync(`${process.env.CLIENT_DIST_PATH}/webpack-assets.json`, 'utf8')
 
 export default (req, res, next) => {
 	const App = renderToString(<Root />)
-	const assets = fs.readFileSync(`${process.env.CLIENT_DIST_PATH}/webpack-assets.json`, 'utf8')
+	const assets = JSON.parse(fs.readFileSync(`webpack-assets`, 'utf8'))
 	const html = Html({App, assets: JSON.parse(assets)})
 	res.send(html)
 }

--- a/src/server/ssr/index.js
+++ b/src/server/ssr/index.js
@@ -1,11 +1,14 @@
 import React from 'react'
 import {renderToString} from 'react-dom/server'
-import assets from 'webpack-assets'
 import Html from './Html'
 import Root from 'common'
+import fs from 'fs'
+// const assets = require(`${process.env.CLIENT_DIST_PATH}/webpack-assets.json`)
+// const assets = fs.readFileSync(`${process.env.CLIENT_DIST_PATH}/webpack-assets.json`, 'utf8')
 
 export default (req, res, next) => {
 	const App = renderToString(<Root />)
-	const html = Html({App, assets})
+	const assets = fs.readFileSync(`${process.env.CLIENT_DIST_PATH}/webpack-assets.json`, 'utf8')
+	const html = Html({App, assets: JSON.parse(assets)})
 	res.send(html)
 }


### PR DESCRIPTION
fix(server): read stats file, instead of importing it.
some users on Linux expected the case when there is no stats file
found. That means server code is already running while stats aren’t
written to dist dir.